### PR TITLE
Help / info page

### DIFF
--- a/src/app/app-global.ts
+++ b/src/app/app-global.ts
@@ -92,14 +92,17 @@ export class AppGlobal {
             shortLabel: 'Users',
             route: 'users',
             icon: 'group'
-        },
-        {
-            label: 'Api status',
-            shortLabel: 'Api status',
-            route: 'status',
-            icon: 'network_check'
         }
     ];
+
+    /*
+    {
+        label: 'Api status',
+        shortLabel: 'Api status',
+        route: 'status',
+        icon: 'network_check'
+    }
+    */
 
     // possible languages, will be used in form and to change the gui language
     public static languagesList: StringLiteral[] = [

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -30,11 +30,16 @@ import { CookiePolicyComponent } from './main/cookie-policy/cookie-policy.compon
 import { GroupsComponent } from './system/groups/groups.component';
 import { PermissionComponent } from './project/permission/permission.component';
 import { ListComponent } from './project/list/list.component';
+import { HelpComponent } from './main/help/help.component';
 
 const routes: Routes = [
     {
         path: '',
         component: MainComponent
+    },
+    {
+        path: 'help',
+        component: HelpComponent
     },
     {
         path: 'login',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -69,6 +69,8 @@ import { ResourceComponent } from './workspace/resource/resource.component';
 import { ResultsComponent } from './workspace/results/results.component';
 import { AdvancedSearchComponent } from './workspace/search/advanced-search/advanced-search.component';
 import { ExpertSearchComponent } from './workspace/search/expert-search/expert-search.component';
+import { HelpComponent } from './main/help/help.component';
+import { FooterComponent } from './main/footer/footer.component';
 
 // translate: AoT requires an exported function for factories
 export function HttpLoaderFactory(httpClient: HttpClient) {
@@ -139,7 +141,9 @@ export function initializeApp(appInitService: AppInitService) {
         ListInfoFormComponent,
         ListItemComponent,
         ListItemFormComponent,
-        MembershipComponent
+        MembershipComponent,
+        HelpComponent,
+        FooterComponent
     ],
     imports: [
         AppRoutingModule,

--- a/src/app/main/footer/footer.component.html
+++ b/src/app/main/footer/footer.component.html
@@ -1,0 +1,69 @@
+<!-- footer with contact, copyright and technology -->
+<footer>
+    <!-- three boxes with technology and support info, contact and social media / code -->
+    <div class="panel">
+        <div class="box about">
+            <p class="mat-body">
+                App is built with
+                <a href="https://angular.io">Angular</a> &middot; Styled with
+                <a href="https://material.angular.io">Material</a> &middot;
+                <a href="http://www.knora.org">Knora</a>
+                and
+                <a href="http://www.sipi.io">Sipi</a> under the hood
+                <br>
+                <br> Supported by the
+                <a href="https://sagw.ch">Swiss Academy of Humanities and Social Sciences</a>.
+            </p>
+        </div>
+        <div class="box contact">
+            <a mat-button href="https://dasch.swiss">Data and Service Center for the Humanities</a>
+            <a mat-button href="https://www.google.com/maps/place/Bernoullistrasse+32%2C+4056+Basel">
+                <mat-icon>location_on</mat-icon> Bernoullistrasse 32, 4056 Basel
+            </a>
+            <a mat-button href="mailto:info@knora.org">
+                <mat-icon>email</mat-icon> info@knora.org
+            </a>
+            <a mat-button href="tel:+41-61-207-04-89">
+                <mat-icon>phone</mat-icon> +41 61 207 04 89
+            </a>
+        </div>
+        <div class="box social-media">
+            <a mat-button href="https://www.github.com/dasch-swiss">
+                <mat-icon>
+                    <svg role="img" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+                        <path
+                              d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z">
+                        </path>
+                    </svg>
+                </mat-icon> dasch-swiss
+            </a>
+            <a mat-button href="https://twitter.com/DaSCHSwiss">
+                <mat-icon>
+                    <svg role="img" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+                        <path
+                              d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z">
+                        </path>
+                    </svg>
+                </mat-icon> DaSCHSwiss
+            </a>
+            <a mat-button href="https://facebook.com/dasch.swiss">
+                <mat-icon>
+                    <svg role="img" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+                        <path
+                              d="M9 8h-3v4h3v12h5v-12h3.642l.358-4h-4v-1.667c0-.955.192-1.333 1.115-1.333h2.885v-5h-3.808c-3.596 0-5.192 1.583-5.192 4.615v3.385z">
+                        </path>
+                    </svg>
+                </mat-icon> dasch.swiss
+            </a>
+        </div>
+    </div>
+
+    <!-- copyright info -->
+    <div class="panel no-padding">
+        <p class="mat-caption">
+            <a href="https://dasch.swiss">DaSCH</a> @
+            <a href="https://unibas.ch">University of Basel</a> &copy; 2017 - {{currentYear.getFullYear()}}
+        </p>
+    </div>
+
+</footer>

--- a/src/app/main/footer/footer.component.scss
+++ b/src/app/main/footer/footer.component.scss
@@ -56,3 +56,23 @@ footer {
     margin-right: 12px;
   }
 }
+
+@media (max-width: 992px) {
+  footer .panel {
+    display: inline;
+
+    .box {
+      width: auto;
+      padding: 0;
+
+      p,
+      a {
+        text-align: center;
+      }
+
+      &.about p {
+        max-width: 100%;
+      }
+    }
+  }
+}

--- a/src/app/main/footer/footer.component.scss
+++ b/src/app/main/footer/footer.component.scss
@@ -1,0 +1,58 @@
+@import "../../../assets/style/config";
+@import "../../../assets/style/mixins";
+@import "../../../assets/style/responsive";
+
+footer {
+  padding: 16px;
+  background: $primary_900;
+  color: $primary_50;
+  min-height: 128px;
+  font-weight: 100;
+  letter-spacing: 1px;
+
+  .panel {
+    align-items: center;
+    display: flex;
+    width: calc(100vw - 32px);
+    text-align: center;
+    margin: 0 auto;
+    position: relative;
+    padding: 50px 30px;
+    box-sizing: border-box;
+
+    &.no-padding {
+      padding-top: 0;
+      padding-bottom: 0;
+      color: $primary_100;
+    }
+
+    p {
+      text-align: center;
+      width: 100%;
+    }
+    .box {
+      box-sizing: content-box;
+      margin: 0;
+      padding: 0 24px;
+      text-align: justify;
+      width: 30%;
+
+      &.about p {
+        max-width: 320px;
+      }
+    }
+  }
+  a {
+    color: inherit;
+    font-weight: 700;
+
+    &.mat-button {
+      display: block;
+      text-align: left;
+    }
+  }
+
+  .mat-icon {
+    margin-right: 12px;
+  }
+}

--- a/src/app/main/footer/footer.component.spec.ts
+++ b/src/app/main/footer/footer.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FooterComponent } from './footer.component';
+
+describe('FooterComponent', () => {
+  let component: FooterComponent;
+  let fixture: ComponentFixture<FooterComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ FooterComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/main/footer/footer.component.spec.ts
+++ b/src/app/main/footer/footer.component.spec.ts
@@ -1,25 +1,29 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FooterComponent } from './footer.component';
+import { MatIconModule } from '@angular/material';
 
 describe('FooterComponent', () => {
-  let component: FooterComponent;
-  let fixture: ComponentFixture<FooterComponent>;
+    let component: FooterComponent;
+    let fixture: ComponentFixture<FooterComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ FooterComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [FooterComponent],
+            imports: [
+                MatIconModule
+            ]
+        })
+            .compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(FooterComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(FooterComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/src/app/main/footer/footer.component.ts
+++ b/src/app/main/footer/footer.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'app-footer',
+    templateUrl: './footer.component.html',
+    styleUrls: ['./footer.component.scss']
+})
+export class FooterComponent implements OnInit {
+
+    currentYear: Date = new Date();
+
+    constructor () { }
+
+    ngOnInit() {
+    }
+
+}

--- a/src/app/main/grid/grid.component.html
+++ b/src/app/main/grid/grid.component.html
@@ -1,15 +1,21 @@
 <div class="app-grid" fxLayout="row wrap" fxLayout.lt-sm="column" fxLayoutGap="24px" fxLayoutAlign="flex-start">
     <div class="app-grid-item" *ngFor="let item of list" fxFlex="0 1 calc(33.3% - 24px)"
          fxFlex.lt-md="0 1 calc(50% - 24px)" fxFlex.lt-sm="100%">
-        <mat-icon *ngIf="item.icon">{{item.icon}}</mat-icon>
+        <mat-icon *ngIf="item.icon" class="topic">{{item.icon}}</mat-icon>
         <!-- <h3>Ensures Longevity of Humanities Data</h3> -->
         <h3>{{item.title}}</h3>
         <p>{{item.text}}</p>
-        <p class="action center">
-            <button mat-button *ngIf="item.url" [routerLink]="[item.url]" routerLinkActive="router-link-active"
-                    color="primary">
-                Read more
+        <br><br>
+        <p class="action center" *ngIf="item.url">
+
+            <button mat-button *ngIf="item.url.substr(0,4) !== 'http'" [routerLink]="[item.url]"
+                    routerLinkActive="router-link-active" color="primary">
+                {{item.urlText ? item.urlText : 'Read more'}}
             </button>
+
+            <a mat-button *ngIf="item.url.substr(0,4) === 'http'" [href]="item.url" target="_blank" color="primary">
+                {{item.urlText ? item.urlText : 'Read more'}} <mat-icon class="suffix">launch</mat-icon>
+            </a>
         </p>
     </div>
 </div>

--- a/src/app/main/grid/grid.component.scss
+++ b/src/app/main/grid/grid.component.scss
@@ -17,7 +17,7 @@
     min-height: 200px;
     position: relative;
 
-    .mat-icon {
+    .mat-icon.topic {
       background: white;
       margin: -28px auto 0;
       padding: 10px;
@@ -37,13 +37,19 @@
     }
 
     .action {
+      margin-top: 24px;
       bottom: 0;
       position: absolute;
       height: 24px;
       width: calc(100% - 60px);
 
-      button {
+      button,
+      a {
         margin: 0 auto;
+
+        .mat-icon {
+          margin-left: 16px;
+        }
       }
     }
 

--- a/src/app/main/grid/grid.component.scss
+++ b/src/app/main/grid/grid.component.scss
@@ -38,7 +38,7 @@
 
     .action {
       margin-top: 24px;
-      bottom: 0;
+      bottom: 16px;
       position: absolute;
       height: 24px;
       width: calc(100% - 60px);
@@ -66,5 +66,10 @@
 @media (max-width: map-get($grid-breakpoints, phone)) {
   .app-grid {
     margin: 50px -15px 0 0;
+    width: 100%;
+
+    .app-grid-item {
+      margin: 12px 0;
+    }
   }
 }

--- a/src/app/main/grid/grid.component.ts
+++ b/src/app/main/grid/grid.component.ts
@@ -4,6 +4,7 @@ export interface GridItem {
     icon?: string;
     title: string;
     url?: string;
+    urlText?: string;
     text: string;
 }
 

--- a/src/app/main/header/header.component.html
+++ b/src/app/main/header/header.component.html
@@ -38,9 +38,12 @@
 
     <!-- action tools: info menu, select language, login button, user menu -->
     <span class="action">
-        <app-info-menu class="info-menu-button"></app-info-menu>
+        <button mat-button [routerLink]="'/help'" class="main-toolbar-button help"> Help </button>
+
         <app-select-language></app-select-language>
-        <button mat-raised-button color="primary" *ngIf="!session" class="login-button" (click)="goToLogin()">LOGIN</button>
+
+        <button mat-raised-button color="primary" *ngIf="!session" class="login-button"
+                (click)="goToLogin()">LOGIN</button>
         <app-user-menu *ngIf="session"></app-user-menu>
     </span>
 
@@ -48,6 +51,7 @@
 
 <!-- search-panel (in phone version) -->
 <div class="search-panel-phone" *ngIf="show">
-    <kui-fulltext-search class="kui-fulltext-search" [route]="'/search'" [projectfilter]="true" (showState)="show=$event">
+    <kui-fulltext-search class="kui-fulltext-search" [route]="'/search'" [projectfilter]="true"
+                         (showState)="show=$event">
     </kui-fulltext-search>
 </div>

--- a/src/app/main/help/help.component.html
+++ b/src/app/main/help/help.component.html
@@ -1,0 +1,36 @@
+<div class="help-page">
+    <section>
+        <div class="content large middle">
+            <h1 class="mat-display-1">Need help?</h1>
+            <h3 class="mat-subheading-2">Explore by section</h3>
+
+            <app-grid id="app-grid-documentation" [list]="docs"></app-grid>
+        </div>
+    </section>
+
+    <section class="darken-bg">
+        <div class="content large middle">
+            <h3 class="mat-subheading-2">Technical Information</h3>
+            <p class="mat-body-1">This web application and the data storage are software tools developed by the Data and
+                Service Center for Humanities DaSCH in Switzerland.</p>
+
+            <app-grid id="app-grid-tools" [list]="tools"></app-grid>
+
+        </div>
+    </section>
+
+    <section>
+        <div class="content large middle">
+            <h3 class="mat-subheading-2">Get more support</h3>
+            <p class="mat-body-1">Need more help or did you had some issues by using our software. Let us know and get
+                in contact on our </p>
+            <a mat-stroked-button href="https://discuss.dasch.swiss" class="middle">Community Forum</a>
+
+            <br><br>
+            <p class="mat-body-1">Wondering what the DaSCH exactly is? Read more on our Website</p>
+            <a mat-stroked-button href="https://dasch.swiss" class="middle">dasch.swiss</a>
+        </div>
+    </section>
+
+    <app-footer></app-footer>
+</div>

--- a/src/app/main/help/help.component.html
+++ b/src/app/main/help/help.component.html
@@ -2,7 +2,7 @@
     <section>
         <div class="content large middle">
             <h1 class="mat-display-1">Need help?</h1>
-            <h3 class="mat-subheading-2">Explore by section</h3>
+            <h3 class="mat-subheading-2">Read the user guide: Explore by topic</h3>
 
             <app-grid id="app-grid-documentation" [list]="docs"></app-grid>
         </div>
@@ -10,9 +10,9 @@
 
     <section class="darken-bg">
         <div class="content large middle">
-            <h3 class="mat-subheading-2">Technical Information</h3>
-            <p class="mat-body-1">This web application and the data storage are software tools developed by the Data and
-                Service Center for Humanities DaSCH in Switzerland.</p>
+            <h3 class="mat-subheading-2">Explore our software products</h3>
+            <p class="mat-body-1">The web application and the tools for data storage and long-term access are developed
+                by the DaSCH team in Switzerland.</p>
 
             <app-grid id="app-grid-tools" [list]="tools"></app-grid>
 
@@ -21,14 +21,9 @@
 
     <section>
         <div class="content large middle">
-            <h3 class="mat-subheading-2">Get more support</h3>
-            <p class="mat-body-1">Need more help or did you had some issues by using our software. Let us know and get
-                in contact on our </p>
-            <a mat-stroked-button href="https://discuss.dasch.swiss" class="middle">Community Forum</a>
+            <h3 class="mat-subheading-2">Get more support or help to improve</h3>
 
-            <br><br>
-            <p class="mat-body-1">Wondering what the DaSCH exactly is? Read more on our Website</p>
-            <a mat-stroked-button href="https://dasch.swiss" class="middle">dasch.swiss</a>
+            <app-grid id="app-grid-tools" [list]="support"></app-grid>
         </div>
     </section>
 

--- a/src/app/main/help/help.component.scss
+++ b/src/app/main/help/help.component.scss
@@ -1,0 +1,15 @@
+@import "../../../assets/style/config";
+@import "../../../assets/style/mixins";
+@import "../../../assets/style/responsive";
+
+section {
+  &.darken-bg {
+    background-color: $primary_50;
+  }
+}
+
+a.middle {
+  margin: 0 auto;
+  display: block;
+  max-width: 200px;
+}

--- a/src/app/main/help/help.component.scss
+++ b/src/app/main/help/help.component.scss
@@ -3,6 +3,20 @@
 @import "../../../assets/style/responsive";
 
 section {
+  background-color: #fff;
+  min-height: 38vh;
+  text-align: center;
+  padding: 24px 0;
+
+  .content {
+    img.logo {
+      max-width: 400px;
+      height: 80px;
+      object-fit: contain;
+      margin: 24px;
+    }
+  }
+
   &.darken-bg {
     background-color: $primary_50;
   }

--- a/src/app/main/help/help.component.spec.ts
+++ b/src/app/main/help/help.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HelpComponent } from './help.component';
+
+describe('HelpComponent', () => {
+  let component: HelpComponent;
+  let fixture: ComponentFixture<HelpComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ HelpComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HelpComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/main/help/help.component.spec.ts
+++ b/src/app/main/help/help.component.spec.ts
@@ -1,25 +1,43 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { MatButtonModule, MatIconModule } from '@angular/material';
+import { RouterTestingModule } from '@angular/router/testing';
+import { KuiCoreConfig, KuiCoreConfigToken } from '@knora/core';
+import { FooterComponent } from '../footer/footer.component';
+import { GridComponent } from '../grid/grid.component';
 import { HelpComponent } from './help.component';
 
+
 describe('HelpComponent', () => {
-  let component: HelpComponent;
-  let fixture: ComponentFixture<HelpComponent>;
+    let component: HelpComponent;
+    let fixture: ComponentFixture<HelpComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ HelpComponent ]
-    })
-    .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [HelpComponent, FooterComponent, GridComponent],
+            imports: [
+                HttpClientTestingModule,
+                MatButtonModule,
+                MatIconModule,
+                RouterTestingModule
+            ],
+            providers: [
+                {
+                    provide: KuiCoreConfigToken,
+                    useValue: KuiCoreConfig
+                }
+            ]
+        })
+            .compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(HelpComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(HelpComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/src/app/main/help/help.component.ts
+++ b/src/app/main/help/help.component.ts
@@ -60,7 +60,7 @@ export class HelpComponent implements OnInit {
         {
             title: 'Knora v',
             text: 'Framework to store, share, and work with primary sources in the humanities.',
-            url: 'https://github.com/dhlab-basel/Kuirl/releases/tag/v',
+            url: 'https://github.com/dhlab-basel/Knora/releases/tag/v',
             urlText: 'Release notes'
         },
         {

--- a/src/app/main/help/help.component.ts
+++ b/src/app/main/help/help.component.ts
@@ -1,0 +1,134 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { GridItem } from '../grid/grid.component';
+import { KuiCoreConfigToken, KuiCoreConfig } from '@knora/core';
+import { DomSanitizer } from '@angular/platform-browser';
+import { MatIconRegistry } from '@angular/material';
+import { HttpResponse, HttpClient } from '@angular/common/http';
+
+
+
+declare let require: any;
+const { version: appVersion } = require('../../../../package.json');
+
+@Component({
+    selector: 'app-help',
+    templateUrl: './help.component.html',
+    styleUrls: ['./help.component.scss']
+})
+export class HelpComponent implements OnInit {
+
+    loading: boolean = true;
+
+    appVersion: string = appVersion;
+    apiVersion: string;
+    akkaVersion: string;
+
+    apiStatus: boolean;
+
+
+    docs: GridItem[] = [
+        {
+            icon: 'assignment',
+            title: 'Project management',
+            text: 'Read more about project administration, collaboration and how to define a data model.',
+            url: 'https://docs.dasch.swiss/user-guide/project',
+            urlText: 'Open Documentation'
+        },
+        {
+            icon: 'edit',
+            title: 'Research tools',
+            text: 'NOT YET IMPLEMENTED -- Get more information about data handling, search methods and how to use the research tools.',
+            url: 'https://docs.dasch.swiss/user-guide/data',
+            urlText: 'Open Documentation'
+        },
+        {
+            icon: 'web',
+            title: 'Publication',
+            text: 'NOT YET IMPLEMENTED',
+            url: 'https://docs.dasch.swiss/user-guide/publication',
+            urlText: 'Open Documentation'
+        }
+    ];
+
+    tools: GridItem[] = [
+        {
+            title: '(s)Kuirl ',
+            text: 'This is the tool in the front-end you are using right now. Knora\'s generic web application.',
+            url: 'https://github.com/dhlab-basel/Kuirl/releases/tag/v',
+            urlText: 'Release notes'
+        },
+        {
+            title: 'Knora v',
+            text: 'Framework to store, share, and work with primary sources in the humanities.',
+            url: 'https://github.com/dhlab-basel/Kuirl/releases/tag/v',
+            urlText: 'Release notes'
+        },
+        {
+            title: 'Sipi v2.0.0',
+            text: 'High-performance, IIIF compatible media storage server.',
+            url: 'https://github.com/dhlab-basel/Sipi/releases/tag/v2.0.0',
+            urlText: 'Release notes'
+        }
+    ];
+
+    constructor (@Inject(KuiCoreConfigToken) public config: KuiCoreConfig,
+        private _domSanitizer: DomSanitizer,
+        private _matIconRegistry: MatIconRegistry,
+        private _http: HttpClient) {
+
+        // create tool icons to use them in mat-icons
+        this._matIconRegistry.addSvgIcon(
+            'kuirl_icon',
+            this._domSanitizer.bypassSecurityTrustResourceUrl('/assets/images/kuirl-icon.svg')
+        );
+        this._matIconRegistry.addSvgIcon(
+            'knora_icon',
+            this._domSanitizer.bypassSecurityTrustResourceUrl('/assets/images/knora-icon.svg')
+        );
+    }
+
+    ngOnInit() {
+
+        // set Kuirl version
+        this.tools[0].title = this.config.name + ' v' + this.appVersion;
+        this.tools[0].url += this.appVersion;
+
+        this._http.get(this.config.api + '/admin/projects', { observe: 'response' })
+            .subscribe(
+                (resp: HttpResponse<any>) => {
+                    // console.log('Stackoverflow', resp.headers.get('Server'));
+                    this.readVersion(resp.headers.get('Server'));
+                    this.apiStatus = true;
+
+                },
+                (error: any) => {
+                    this.readVersion(error.headers.get('Server'));
+                    console.error(error);
+                    // console.log('Stackoverflow', error.headers.get('Server'));
+                    this.apiStatus = false;
+                }
+            );
+    }
+
+    readVersion(v: string) {
+
+        if (!v) {
+            return;
+        }
+
+        // read and set version of knora
+        const versions: string[] = v.split(' ');
+
+        this.apiVersion = versions[0].split('/')[1].substring(0, 5);
+        this.akkaVersion = versions[1].split('/')[1];
+
+        this.tools[1].title += this.apiVersion;
+        this.tools[1].url += this.apiVersion;
+        // this.versions[2].label += this.akkaVersion;
+        // this.versions[2].route += this.akkaVersion;
+
+        this.loading = false;
+
+    }
+
+}

--- a/src/app/main/help/help.component.ts
+++ b/src/app/main/help/help.component.ts
@@ -37,7 +37,7 @@ export class HelpComponent implements OnInit {
         {
             icon: 'edit',
             title: 'Research tools',
-            text: 'NOT YET IMPLEMENTED -- Get more information about data handling, search methods and how to use the research tools.',
+            text: 'NOT FULLY IMPLEMENTED - Get more information about data handling, search methods and how to use the research tools.',
             url: 'https://docs.dasch.swiss/user-guide/data',
             urlText: 'Open Documentation'
         },
@@ -53,7 +53,7 @@ export class HelpComponent implements OnInit {
     tools: GridItem[] = [
         {
             title: '(s)Kuirl ',
-            text: 'This is the tool in the front-end you are using right now. Knora\'s generic web application.',
+            text: 'This is the tool of the user interface you are using right now. Knora\'s generic web application.',
             url: 'https://github.com/dhlab-basel/Kuirl/releases/tag/v',
             urlText: 'Release notes'
         },
@@ -74,7 +74,7 @@ export class HelpComponent implements OnInit {
     support: GridItem[] = [
         {
             title: 'Need more help?',
-            text: 'Did you had some issues by using our software. Let us know and get in contact with developers and users:',
+            text: 'Have you had some issues by using our software? Let us know and get in contact with developers and users:',
             url: 'https://discuss.dasch.swiss',
             urlText: 'DaSCH Forum'
         },

--- a/src/app/main/help/help.component.ts
+++ b/src/app/main/help/help.component.ts
@@ -71,6 +71,27 @@ export class HelpComponent implements OnInit {
         }
     ];
 
+    support: GridItem[] = [
+        {
+            title: 'Need more help?',
+            text: 'Did you had some issues by using our software. Let us know and get in contact with developers and users:',
+            url: 'https://discuss.dasch.swiss',
+            urlText: 'DaSCH Forum'
+        },
+        {
+            title: 'DaSCH infrastructure',
+            text: 'Wondering what the Data and Service Center for the Humanities DaSCH exactly is? Get more information on our Website:',
+            url: 'https://dasch.swiss',
+            urlText: 'dasch.swiss'
+        },
+        {
+            title: 'Contribute',
+            text: 'All our software code is open source and accessible on Github. If you want to improve the tools, feel free to contact us on:',
+            url: 'https://github.com/dasch-swiss',
+            urlText: 'Github'
+        }
+    ];
+
     constructor (@Inject(KuiCoreConfigToken) public config: KuiCoreConfig,
         private _domSanitizer: DomSanitizer,
         private _matIconRegistry: MatIconRegistry,

--- a/src/app/main/info-menu/info-menu.component.html
+++ b/src/app/main/info-menu/info-menu.component.html
@@ -1,24 +1,40 @@
 <button mat-button [matMenuTriggerFor]="infoMenu" class="main-toolbar-button info-menu">
-  <mat-icon class="custom">network_check</mat-icon>
+    <!-- <mat-icon class="custom">help_outline</mat-icon> -->
+    Help
 </button>
 
 <mat-menu #infoMenu="matMenu" xPosition="before" class="menu">
-  <div class="menu-header" [class.inactive]="!apiStatus">
-    <p class="menu-title">
-      Status
-    </p>
-  </div>
-  <div class="menu-content" *ngIf="!loading">
-    <mat-list class="navigation">
-      <mat-list-item class="nav-item" *ngFor="let item of versions">
-        <a [href]="item.route" target="_blank" mat-button class="nav-item button">
-          <mat-icon class="prefix" [svgIcon]="item.icon"></mat-icon>
-          <span class="label">{{item.label}}</span>
-        </a>
-      </mat-list-item>
-    </mat-list>
-  </div>
-  <div class="menu-footer">
+    <div class="menu-header" [class.inactive]="!apiStatus">
+        <p class="menu-title">
+            Need help?
+        </p>
+    </div>
+    <div class="menu-content">
+        <mat-list class="navigation">
+            <!-- Documentation -->
+            <mat-list-item>
+                <button mat-button [routerLink]="'/system'" routerLinkActive="active-link"
+                        class="nav-item button border-top">
+                    <mat-icon class="prefix">all_inbox</mat-icon>
+                    <span class="label">System</span>
+                </button>
+            </mat-list-item>
 
-  </div>
+            <!-- About -->
+
+            <!-- Version -->
+            <!-- *ngIf="!loading" -->
+            <mat-list-item *ngFor="let item of versions; let i = index" class="nav-item" [class.border-top]="i === 0">
+                <a [href]="item.route" target="_blank" mat-button class="nav-item button">
+                    <mat-icon class="prefix" [svgIcon]="item.icon"></mat-icon>
+                    <span class="label">{{item.label}}</span>
+                </a>
+            </mat-list-item>
+
+
+        </mat-list>
+    </div>
+    <div class="menu-footer border-top">
+        Contact
+    </div>
 </mat-menu>

--- a/src/app/main/info-menu/info-menu.component.scss
+++ b/src/app/main/info-menu/info-menu.component.scss
@@ -1,4 +1,4 @@
 a.mat-button {
-  text-align: center !important;
+  //   text-align: center !important;
   padding-top: 5px;
 }

--- a/src/app/main/info-menu/info-menu.component.spec.ts
+++ b/src/app/main/info-menu/info-menu.component.spec.ts
@@ -4,42 +4,44 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatMenuModule } from '@angular/material/menu';
+import { RouterTestingModule } from '@angular/router/testing';
 import { KuiCoreConfig, KuiCoreConfigToken, KuiCoreModule } from '@knora/core';
 import { InfoMenuComponent } from './info-menu.component';
 
 
 describe('InfoMenuComponent', () => {
-  let component: InfoMenuComponent;
-  let fixture: ComponentFixture<InfoMenuComponent>;
+    let component: InfoMenuComponent;
+    let fixture: ComponentFixture<InfoMenuComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [InfoMenuComponent],
-      imports: [
-        HttpClientTestingModule,
-        KuiCoreModule,
-        MatButtonModule,
-        MatIconModule,
-        MatListModule,
-        MatMenuModule
-      ],
-      providers: [
-        {
-          provide: KuiCoreConfigToken,
-          useValue: KuiCoreConfig
-        }
-      ]
-    })
-      .compileComponents();
-  }));
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [InfoMenuComponent],
+            imports: [
+                HttpClientTestingModule,
+                KuiCoreModule,
+                MatButtonModule,
+                MatIconModule,
+                MatListModule,
+                MatMenuModule,
+                RouterTestingModule
+            ],
+            providers: [
+                {
+                    provide: KuiCoreConfigToken,
+                    useValue: KuiCoreConfig
+                }
+            ]
+        })
+            .compileComponents();
+    }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(InfoMenuComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(InfoMenuComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
 });

--- a/src/app/main/info-menu/info-menu.component.ts
+++ b/src/app/main/info-menu/info-menu.component.ts
@@ -40,7 +40,7 @@ export class InfoMenuComponent implements OnInit {
         @Inject(KuiCoreConfigToken) public config: KuiCoreConfig,
         private _domSanitizer: DomSanitizer,
         private _matIconRegistry: MatIconRegistry,
-        private _http: HttpClient, ) {
+        private _http: HttpClient) {
 
         // create tool icons to use them in mat-icons
         this._matIconRegistry.addSvgIcon(
@@ -69,6 +69,7 @@ export class InfoMenuComponent implements OnInit {
                     // console.log('Stackoverflow', resp.headers.get('Server'));
                     this.readVersion(resp.headers.get('Server'));
                     this.apiStatus = true;
+
                 },
                 (error: any) => {
                     this.readVersion(error.headers.get('Server'));
@@ -79,6 +80,7 @@ export class InfoMenuComponent implements OnInit {
             );
 
     }
+
 
     readVersion(v: string) {
 

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -32,7 +32,7 @@
     <section class="features">
         <div class="content large middle">
             <h2 class="mat-title">The web application offers all features from Knora in a friendly designed way</h2>
-            <app-grid id="app-grid-features" [list]="features"></app-grid>
+            <app-grid [list]="features"></app-grid>
         </div>
     </section>
 

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -2,7 +2,8 @@
 <div class="landing-page">
     <div class="cookie-banner" *ngIf="showCookieBanner">
         <p class="note">
-            This web-application uses cookies to provide you with great user experience. By using the application you accept our
+            This web-application uses cookies to provide you with great user experience. By using the application you
+            accept our
             <a href="./cookie-policy">use of cookies</a>.
         </p>
         <div class="action">
@@ -17,7 +18,10 @@
             <div class="content medium middle">
                 <!-- <h2 class="mat-title">Knora User Interface &middot; Research Layer</h2> -->
                 <h1 class="mat-display-2 app-headline">bring all together and simplify your research</h1>
-                <h2 class="mat-title">This is the generic web application of the Data and Service Center for Humanities DaSCH. It's the user interface research layer of Knora &ndash; a software framework for storing, sharing, and working with primary sources and all kind of data in your research project in humanities.
+                <h2 class="mat-title">This is the generic web application of the Data and Service Center for Humanities
+                    DaSCH. It's the user interface research layer of Knora &ndash; a software framework for storing,
+                    sharing, and working with primary sources and all kind of data in your research project in
+                    humanities.
                 </h2>
             </div>
         </div>
@@ -49,7 +53,9 @@
                 <div *ngSwitchCase="'qualitative'">
                     <h2 class="mat-title">Hooray, you're in the right place.</h2>
                     <mat-divider class="more-space-bottom"></mat-divider>
-                    <h4 class="mat-subheading-2">The tool is designed to work with qualitative data. You can upload and transcribe taped interviews. Describe images, photographs. Annotate the data and connect every kind of media with each other.</h4>
+                    <h4 class="mat-subheading-2">The tool is designed to work with qualitative data. You can upload and
+                        transcribe taped interviews. Describe images, photographs. Annotate the data and connect every
+                        kind of media with each other.</h4>
                     <mat-divider class="more-space-bottom"></mat-divider>
                     <a mat-raised-button [color]="'accent'" href="https://dasch.swiss/team">Please contact us</a>
                 </div>
@@ -57,7 +63,8 @@
                 <div *ngSwitchCase="'quantitative'">
                     <h2 class="mat-title">Uh-oh, unfortunately you're in the wrong place</h2>
                     <mat-divider class="more-space-bottom"></mat-divider>
-                    <h4 class="mat-subheading-2">The tool is designed to work with qualitative data. If you are looking for a tool to work with quantitative data, you should contact
+                    <h4 class="mat-subheading-2">The tool is designed to work with qualitative data. If you are looking
+                        for a tool to work with quantitative data, you should contact
                         <a href="https://forscenter.ch/">FORS</a>.
                     </h4>
                     <mat-divider class="more-space-bottom"></mat-divider>
@@ -67,7 +74,8 @@
                 <div *ngSwitchCase="'edition'">
                     <h2 class="mat-title">Uh-oh, unfortunately you're in the wrong place</h2>
                     <mat-divider class="more-space-bottom"></mat-divider>
-                    <h4 class="mat-subheading-2">There's another tool which is designed to work on editions, but also based on Knora. For this kind of research you should contact
+                    <h4 class="mat-subheading-2">There's another tool which is designed to work on editions, but also
+                        based on Knora. For this kind of research you should contact
                         <a href="https://nie-ine.ch/">NIE-INE</a>.
                     </h4>
                     <mat-divider class="more-space-bottom"></mat-divider>
@@ -108,7 +116,9 @@
         <div class="content medium middle">
             <h2 class="mat-title">Who's behind all that?</h2>
             <h3 class="mat-subheading-2">
-                Since 2017, the Data and Service Center for humanities (DaSCH) has been a member of the Swiss Academy of Humanities and Social Sciences. The main task of the institution is to operate a platform for humanities research data that ensures access to this data.
+                Since 2017, the Data and Service Center for humanities (DaSCH) has been a member of the Swiss Academy of
+                Humanities and Social Sciences. The main task of the institution is to operate a platform for humanities
+                research data that ensures access to this data.
             </h3>
             <a href="https://dasch.swiss/" target="_blank">
                 <img class="logo logo-dasch" src="/assets/images/logo-dasch.jpg">
@@ -128,71 +138,6 @@
         </div>
     </section>
 
-    <!-- footer with contact, copyright and technology -->
-    <footer>
-        <!-- three boxes with technology and support info, contact and social media / code -->
-        <div class="panel">
-            <div class="box about">
-                <p class="mat-body">
-                    Built with
-                    <a href="https://angular.io">Angular</a> &middot; Styled with
-                    <a href="https://material.angular.io">Material</a> &middot;
-                    <a href="http://www.knora.org">Knora</a>
-                    and
-                    <a href="http://www.sipi.io">Sipi</a> under the hood
-                    <br>
-                    <br> Supported by the
-                    <a href="https://sagw.ch">Swiss Academy of Humanities and Social Sciences</a>.
-                </p>
-            </div>
-            <div class="box contact">
-                <a mat-button href="https://dasch.swiss">Data and Service Center for the Humanities</a>
-                <a mat-button href="https://www.google.com/maps/place/Bernoullistrasse+32%2C+4056+Basel">
-                    <mat-icon>location_on</mat-icon> Bernoullistrasse 32, 4056 Basel
-                </a>
-                <a mat-button href="mailto:info@knora.org">
-                    <mat-icon>email</mat-icon> info@knora.org
-                </a>
-                <a mat-button href="tel:+41-61-207-04-89">
-                    <mat-icon>phone</mat-icon> +41 61 207 04 89
-                </a>
-            </div>
-            <div class="box social-media">
-                <a mat-button href="https://www.github.com/dhlab-basel">
-                    <mat-icon>
-                        <svg role="img" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z">
-                            </path>
-                        </svg>
-                    </mat-icon> dhlab-basel
-                </a>
-                <a mat-button href="https://twitter.com/DaSCHSwiss">
-                    <mat-icon>
-                        <svg role="img" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z">
-                            </path>
-                        </svg>
-                    </mat-icon> DaSCHSwiss
-                </a>
-                <a mat-button href="https://facebook.com/dasch.swiss">
-                    <mat-icon>
-                        <svg role="img" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M9 8h-3v4h3v12h5v-12h3.642l.358-4h-4v-1.667c0-.955.192-1.333 1.115-1.333h2.885v-5h-3.808c-3.596 0-5.192 1.583-5.192 4.615v3.385z">
-                            </path>
-                        </svg>
-                    </mat-icon> dasch.swiss
-                </a>
-            </div>
-        </div>
-
-        <!-- copyright info -->
-        <div class="panel no-padding">
-            <p class="mat-caption">
-                <a href="https://dasch.swiss">DaSCH</a> @
-                <a href="https://unibas.ch">University of Basel</a> &copy; 2018 - {{currentYear.getFullYear()}}
-            </p>
-        </div>
-
-    </footer>
+    <app-footer></app-footer>
 
 </div>

--- a/src/app/main/main.component.scss
+++ b/src/app/main/main.component.scss
@@ -111,23 +111,6 @@ section {
   .parallax-wrapper {
     background-attachment: scroll !important;
   }
-
-  footer .panel {
-    display: inline;
-
-    .box {
-      width: auto;
-
-      p,
-      a {
-        text-align: center;
-      }
-
-      &.about p {
-        max-width: 100%;
-      }
-    }
-  }
 }
 
 // phone devices
@@ -140,12 +123,7 @@ section {
   .landing-page {
     .features,
     .projects {
-      width: calc(100% - 16px);
-    }
-    app-grid[id="app-grid-features"] {
-      div.app-grid {
-        margin: 10px -15px 0 0;
-      }
+      //   width: calc(100% - 16px);
     }
   }
 

--- a/src/app/main/main.component.scss
+++ b/src/app/main/main.component.scss
@@ -74,61 +74,6 @@ section {
   }
 }
 
-footer {
-  padding: 16px;
-  background: $primary_900;
-  color: $primary_50;
-  min-height: 128px;
-  font-weight: 100;
-  letter-spacing: 1px;
-
-  .panel {
-    align-items: center;
-    display: flex;
-    width: calc(100vw - 32px);
-    text-align: center;
-    margin: 0 auto;
-    position: relative;
-    padding: 50px 30px;
-    box-sizing: border-box;
-
-    &.no-padding {
-      padding-top: 0;
-      padding-bottom: 0;
-      color: $primary_100;
-    }
-
-    p {
-      text-align: center;
-      width: 100%;
-    }
-    .box {
-      box-sizing: content-box;
-      margin: 0;
-      padding: 0 24px;
-      text-align: justify;
-      width: 30%;
-
-      &.about p {
-        max-width: 320px;
-      }
-    }
-  }
-  a {
-    color: inherit;
-    font-weight: 700;
-
-    &.mat-button {
-      display: block;
-      text-align: left;
-    }
-  }
-
-  .mat-icon {
-    margin-right: 12px;
-  }
-}
-
 .cookie-banner {
   position: fixed;
   bottom: 0;
@@ -179,7 +124,7 @@ footer {
       }
 
       &.about p {
-       max-width: 100%;
+        max-width: 100%;
       }
     }
   }
@@ -191,14 +136,16 @@ footer {
     height: 140px;
   }
 
+  .help-page,
   .landing-page {
-    .features, .projects {
+    .features,
+    .projects {
       width: calc(100% - 16px);
     }
     app-grid[id="app-grid-features"] {
       div.app-grid {
         margin: 10px -15px 0 0;
-      }  
+      }
     }
   }
 

--- a/src/app/main/main.component.spec.ts
+++ b/src/app/main/main.component.spec.ts
@@ -8,6 +8,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { KuiActionModule } from '@knora/action';
 import { KuiAuthenticationModule } from '@knora/authentication';
 import { KuiCoreConfig, KuiCoreConfigToken } from '@knora/core';
+import { FooterComponent } from './footer/footer.component';
 import { GridComponent } from './grid/grid.component';
 import { MainComponent } from './main.component';
 
@@ -17,7 +18,7 @@ describe('MainComponent', () => {
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [MainComponent, GridComponent],
+            declarations: [MainComponent, FooterComponent, GridComponent],
             imports: [
                 KuiActionModule,
                 KuiAuthenticationModule,

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -62,9 +62,7 @@ export class MainComponent implements OnInit {
         }
     ];
 
-    currentYear: Date = new Date();
-
-    constructor(
+    constructor (
         private _auth: AuthenticationService,
         private _projectsService: ProjectsService,
         private _router: Router,


### PR DESCRIPTION
Resolves #82 and closes #81 

Moved the status/info menu to an own page including links to user-guide documentation, links to github development / release notes and links to dasch.swiss and discuss / forum page.

Separate footer which can be used on the main landing page and on this new help page